### PR TITLE
Move Track into separate file

### DIFF
--- a/src/recent.ts
+++ b/src/recent.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import Track from './track';
 
 export class RecentProvider implements vscode.TreeDataProvider<Track> {
     constructor(private spotify: any) {}
@@ -10,7 +11,7 @@ export class RecentProvider implements vscode.TreeDataProvider<Track> {
         }
         return Promise.resolve(this.spotify.getMyRecentlyPlayedTracks({limit: 50}).then(
             (data: any) => {
-                return Promise.resolve(data.body.items.map((x: any) => new Track(x.track.artists, x.track.name)));
+                return Promise.resolve(data.body.items.map((x: any) => new Track(x.track)));
             },
             (error: any) => {
                 vscode.window.showErrorMessage(error);
@@ -21,15 +22,4 @@ export class RecentProvider implements vscode.TreeDataProvider<Track> {
     getTreeItem(element: Track): vscode.TreeItem {
 		return element;
 	}
-}
-
-export class Track extends vscode.TreeItem {
-    constructor(
-        public readonly artists: any[],
-        public readonly name: string
-    ) {
-        super(name);
-        this.description = artists.map(x => x.name).join(', ');
-        this.tooltip = new vscode.MarkdownString(`**${name}**  \n${artists.map(x => x.name).join(', ')}`);
-    }
 }

--- a/src/track.ts
+++ b/src/track.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode';
+
+/**
+ * A single track on Spotify.
+ * @extends vscode.TreeItem
+ * @param {any} track - Track object returned from Spotify (likely in `data.body.items[]`)
+ */
+export default class Track extends vscode.TreeItem {
+    artists: any[];
+    name: string;
+    constructor(
+        private readonly track: any
+    ) {
+        super(track.name);
+        this.name = track.name;
+        this.artists = track.artists;
+
+        this.description = this.artists.map(x => x.name).join(', ');
+        this.tooltip = new vscode.MarkdownString(`**${this.name}**  \n${this.artists.map(x => x.name).join(', ')}`);
+    }
+}


### PR DESCRIPTION
Closes #12 

This class functions as a `TreeItem` for `TreeView`s but could also be a generic class to represent Spotify tracks in other contexts if we need. I wanted to separate it from the `RecentProvider` tree view thingy.