### PR TITLE
Delete unused panels

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,6 @@
 		"views": {
 			"spotify": [
 				{
-					"id": "spotify-queue",
-					"name": "Queue",
-					"icon": "media/icon.svg",
-					"visibility": "collapsed"
-				},
-				{
 					"id": "spotify-personalized-playlists",
 					"name": "Made For You",
 					"icon": "media/icon.svg",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,6 @@
 		"views": {
 			"spotify": [
 				{
-					"id": "spotify-personalized-playlists",
-					"name": "Made For You",
-					"icon": "media/icon.svg",
-					"visibility": "collapsed"
-				},
-				{
 					"id": "spotify-recent",
 					"name": "Recently Played",
 					"icon": "media/icon.svg",


### PR DESCRIPTION
There are two panels that are in the Spotify client but not in the Spotify Web API, so I'd rather remove the placeholders until we can implement them.

- Queue (requires alternative backend, see #7)
- Made For You (unsure how this is implemented)