### PR TITLE
View Actions for History panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^8.0.4",
 		"@types/node": "^12.11.7",
+		"@types/spotify-api": "0.0.7",
 		"@types/spotify-web-api-node": "^5.0.0",
 		"@types/vscode": "^1.53.0",
 		"@typescript-eslint/eslint-plugin": "^4.14.1",

--- a/package.json
+++ b/package.json
@@ -24,18 +24,6 @@
 				"command": "spotifymlh.pause",
 				"category": "Spotify",
 				"title": "Pause"
-			},
-			{
-				"command": "spotifymlh.track.play",
-				"category": "Spotify",
-				"title": "Play",
-				"icon": "$(play)"
-			},
-			{
-				"command": "spotifymlh.track.queue",
-				"category": "Spotify",
-				"title": "Add track to queue",
-				"icon": "$(add)"
 			}
 		],
 		"menus": {

--- a/package.json
+++ b/package.json
@@ -32,14 +32,12 @@
 			},
 			{
 				"command": "spotifymlh.track.play",
-				"category": "Spotify",
 				"title": "Play",
 				"icon": "$(play)"
 			},
 			{
 				"command": "spotifymlh.track.queue",
-				"category": "Spotify",
-				"title": "Add track to queue",
+				"title": "Add to Queue",
 				"icon": "$(add)"
 			}
 		],
@@ -47,12 +45,12 @@
 			"view/item/context": [
 				{
 					"command": "spotifymlh.track.play",
-					"when": "view == spotify-history",
+					"when": "viewItem == track",
 					"group": "inline"
 				},
 				{
 					"command": "spotifymlh.track.queue",
-					"when": "view == spotify-history",
+					"when": "viewItem == track",
 					"group": "inline"
 				}
 			],

--- a/package.json
+++ b/package.json
@@ -24,8 +24,34 @@
 				"command": "spotifymlh.pause",
 				"category": "Spotify",
 				"title": "Pause"
+			},
+			{
+				"command": "spotifymlh.track.play",
+				"category": "Spotify",
+				"title": "Play",
+				"icon": "$(play)"
+			},
+			{
+				"command": "spotifymlh.track.queue",
+				"category": "Spotify",
+				"title": "Add track to queue",
+				"icon": "$(add)"
 			}
 		],
+		"menus": {
+			"view/item/context": [
+				{
+					"command": "spotifymlh.track.play",
+					"when": "view == spotify-recent",
+					"group": "inline"
+				},
+				{
+					"command": "spotifymlh.track.queue",
+					"when": "view == spotify-recent",
+					"group": "inline"
+				}
+			]
+		},
 		"views": {
 			"spotify": [
 				{

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
 	"contributes": {
 		"commands": [
 			{
+				"command": "spotifymlh.history.newer",
+				"title": "Load newer tracks",
+				"icon": "$(refresh)"
+			},
+			{
 				"command": "spotifymlh.play",
 				"category": "Spotify",
 				"title": "Play"
@@ -49,6 +54,13 @@
 					"command": "spotifymlh.track.queue",
 					"when": "view == spotify-history",
 					"group": "inline"
+				}
+			],
+			"view/title": [
+				{
+					"command": "spotifymlh.history.newer",
+					"when": "view == spotify-history",
+					"group": "navigation"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
 			"view/item/context": [
 				{
 					"command": "spotifymlh.track.play",
-					"when": "view == spotify-recent",
+					"when": "view == spotify-history",
 					"group": "inline"
 				},
 				{
 					"command": "spotifymlh.track.queue",
-					"when": "view == spotify-recent",
+					"when": "view == spotify-history",
 					"group": "inline"
 				}
 			]
@@ -67,8 +67,8 @@
 					"visibility": "collapsed"
 				},
 				{
-					"id": "spotify-recent",
-					"name": "Recently Played",
+					"id": "spotify-history",
+					"name": "History",
 					"icon": "media/icon.svg",
 					"visibility": "collapsed"
 				},

--- a/package.json
+++ b/package.json
@@ -42,6 +42,12 @@
 			}
 		],
 		"menus": {
+			"commandPalette": [
+				{
+					"command": "spotifymlh.history.newer",
+					"when": "false"
+				}
+			],
 			"view/item/context": [
 				{
 					"command": "spotifymlh.track.play",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,18 @@
 				"command": "spotifymlh.pause",
 				"category": "Spotify",
 				"title": "Pause"
+			},
+			{
+				"command": "spotifymlh.track.play",
+				"category": "Spotify",
+				"title": "Play",
+				"icon": "$(play)"
+			},
+			{
+				"command": "spotifymlh.track.queue",
+				"category": "Spotify",
+				"title": "Add track to queue",
+				"icon": "$(add)"
 			}
 		],
 		"menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
 	const historyProvider = new HistoryProvider(spotify);
 	vscode.window.registerTreeDataProvider('spotify-history', historyProvider);
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.history.newer", () => {
-		historyProvider.refresh();
+		historyProvider.loadNewTracks();
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.play", () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as crypto from 'crypto';
 import * as vscode from 'vscode';
 const express = require('express');
 const SpotifyWebApi = require('spotify-web-api-node');
-import { RecentProvider } from './recent';
+import { HistoryProvider } from './history';
 import { clientId, clientSecret } from './secrets';
 import Track from './track';
 
@@ -43,7 +43,7 @@ export function activate(context: vscode.ExtensionContext) {
 		spotify.addToQueue(track.uri);
 	}));
 
-	vscode.window.registerTreeDataProvider('spotify-recent', new RecentProvider(spotify));
+	vscode.window.registerTreeDataProvider('spotify-history', new HistoryProvider(spotify));
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,11 +23,8 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 	spotifyAuthentication(spotify);
 
-	const historyProvider = new HistoryProvider(spotify);
+	const historyProvider = new HistoryProvider(spotify, context);
 	vscode.window.registerTreeDataProvider('spotify-history', historyProvider);
-	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.history.newer", () => {
-		historyProvider.loadNewTracks();
-	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.play", () => {
 		//logic for play on spotify goes here

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,11 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 	spotifyAuthentication(spotify);
 
+	const historyProvider = new HistoryProvider(spotify);
+	vscode.window.registerTreeDataProvider('spotify-history', historyProvider);
+	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.history.newer", () => {
+		historyProvider.refresh();
+	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.play", () => {
 		//logic for play on spotify goes here
@@ -43,8 +48,6 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.track.queue", (track: Track) => {
 		spotify.addToQueue(track.uri);
 	}));
-
-	vscode.window.registerTreeDataProvider('spotify-history', new HistoryProvider(spotify));
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ const express = require('express');
 const SpotifyWebApi = require('spotify-web-api-node');
 import { RecentProvider } from './recent';
 import { clientId, clientSecret } from './secrets';
+import Track from './track';
 
 // Auth config
 const PATH = '/spotify-callback';
@@ -30,6 +31,16 @@ export function activate(context: vscode.ExtensionContext) {
 		// TODO: handle errors etc., see documentation
 		vscode.window.showInformationMessage('Attempting to pause...');
 		spotify.pause();
+	}));
+
+	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.track.play", (track: Track) => {
+		// Spotify Web API doesn't currently have a way to start playback fresh from a track, so this is a hack
+		spotify.addToQueue(track.uri)
+			.then(() => spotify.skipToNext());
+	}));
+	
+	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.track.queue", (track: Track) => {
+		spotify.addToQueue(track.uri);
 	}));
 
 	vscode.window.registerTreeDataProvider('spotify-recent', new RecentProvider(spotify));

--- a/src/history.ts
+++ b/src/history.ts
@@ -3,23 +3,42 @@ import * as vscode from 'vscode';
 import Track from './track';
 
 export class HistoryProvider implements vscode.TreeDataProvider<Track> {
+    private _onDidChangeTreeData: vscode.EventEmitter<Track | undefined | null | void> = new vscode.EventEmitter<Track | undefined | null | void>();
+    readonly onDidChangeTreeData: vscode.Event<Track | undefined | null | void> = this._onDidChangeTreeData.event;
+    private after?: number = undefined;
+    public tracks: Track[] = [];
+    
     constructor(private spotify: SpotifyWebApi) {}
 
     getChildren(element?: Track): Thenable<Track[]> {
         if (element) {
+            // Tracks do not have children
             return Promise.resolve([]);
         }
-        return Promise.resolve(this.spotify.getMyRecentlyPlayedTracks({limit: 50}).then(
+        
+        return Promise.resolve(this.spotify.getMyRecentlyPlayedTracks({
+            after: this.after,
+            limit: 50
+        }).then(
             (data: any) => {
-                return Promise.resolve(data.body.items.map((x: any) => new Track(x.track)));
+                if (data.body.items.length === 0) {
+                    vscode.window.showInformationMessage("Spotify didn't return any newer tracks.");
+                    return; // Skip to the next promise in the chain
+                }
+                this.after = data.body.cursors.after;
+                this.tracks = data.body.items.map((x: any) => new Track(x.track)).concat(this.tracks);
             },
             (error: any) => {
                 vscode.window.showErrorMessage(error);
             }
-        ));
+        ).then(() => { return Promise.resolve(this.tracks); }));
     }
 
     getTreeItem(element: Track): vscode.TreeItem {
 		return element;
 	}
+
+    refresh(): void {
+        this._onDidChangeTreeData.fire();
+    }
 }

--- a/src/history.ts
+++ b/src/history.ts
@@ -8,7 +8,11 @@ export class HistoryProvider implements vscode.TreeDataProvider<Track> {
     private after?: number = undefined;
     public tracks: Track[] = [];
     
-    constructor(private spotify: SpotifyWebApi) {}
+    constructor(private spotify: SpotifyWebApi, private readonly context: vscode.ExtensionContext) {
+        context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.history.newer", () => {
+            this.loadNewTracks();
+        }));
+    }
 
     getChildren(element?: Track): Thenable<Track[]> {
         if (element) {

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,8 +1,9 @@
+import SpotifyWebApi = require('spotify-web-api-node');
 import * as vscode from 'vscode';
 import Track from './track';
 
 export class HistoryProvider implements vscode.TreeDataProvider<Track> {
-    constructor(private spotify: any) {}
+    constructor(private spotify: SpotifyWebApi) {}
 
     getChildren(element?: Track): Thenable<Track[]> {
         if (element) {

--- a/src/history.ts
+++ b/src/history.ts
@@ -5,7 +5,6 @@ export class HistoryProvider implements vscode.TreeDataProvider<Track> {
     constructor(private spotify: any) {}
 
     getChildren(element?: Track): Thenable<Track[]> {
-        // TODO: implement
         if (element) {
             return Promise.resolve([]);
         }

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import Track from './track';
 
-export class RecentProvider implements vscode.TreeDataProvider<Track> {
+export class HistoryProvider implements vscode.TreeDataProvider<Track> {
     constructor(private spotify: any) {}
 
     getChildren(element?: Track): Thenable<Track[]> {

--- a/src/history.ts
+++ b/src/history.ts
@@ -2,15 +2,52 @@ import SpotifyWebApi = require('spotify-web-api-node');
 import * as vscode from 'vscode';
 import Track from './track';
 
+/**
+ * TreeDataProvider for playback history
+ * @extends vscode.TreeDataProvider
+ * @param {SpotifyWebApi} spotify - Spotify API object to make calls with
+ * @param {vscode.ExtensionContext} context - Extension context to register commands in
+ */
 export class HistoryProvider implements vscode.TreeDataProvider<Track> {
     private _onDidChangeTreeData: vscode.EventEmitter<Track | undefined | null | void> = new vscode.EventEmitter<Track | undefined | null | void>();
     readonly onDidChangeTreeData: vscode.Event<Track | undefined | null | void> = this._onDidChangeTreeData.event;
     private after?: number = undefined;
+    private before?: number = undefined;
     public tracks: Track[] = [];
     
     constructor(private spotify: SpotifyWebApi, private readonly context: vscode.ExtensionContext) {
         context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.history.newer", () => {
-            this.loadNewTracks();
+            this.spotify.getMyRecentlyPlayedTracks({ after: this.after, limit: 50 }).then(
+                data => {
+                    if (data.body.items.length === 0) {
+                        vscode.window.showInformationMessage("Spotify didn't return any newer history.");
+                        return;
+                    }
+                    this.after = Number(data.body.cursors.after);
+                    if (!this.before) {
+                        // Only update with initial population of the TreeView
+                        // Updates will be handled by spotifymlh.history.older
+                        this.before = Number(data.body.cursors.before);
+                    }
+                    this.tracks = data.body.items.map((x: any) => new Track(x.track)).concat(this.tracks);
+                    this._onDidChangeTreeData.fire(); // Tell VS Code that the TreeItems have changed
+                },
+                error => vscode.window.showErrorMessage(error)
+            );
+        }));
+        context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.history.older", () => {
+            this.spotify.getMyRecentlyPlayedTracks({ before: this.before, limit: 50 }).then(
+                data => {
+                    if (data.body.items.length === 0) {
+                        vscode.window.showInformationMessage("Spotify didn't return any older history.");
+                        return;
+                    }
+                    this.before = Number(data.body.cursors.before);
+                    this.tracks.push(...data.body.items.map((x: any) => new Track(x.track)));
+                    this._onDidChangeTreeData.fire(); // Tell VS Code that the TreeItems have changed
+                },
+                error => vscode.window.showErrorMessage(error)
+            );
         }));
     }
 
@@ -21,10 +58,10 @@ export class HistoryProvider implements vscode.TreeDataProvider<Track> {
         }
 
         if (this.tracks.length === 0) {
-            this.loadNewTracks();
+            vscode.commands.executeCommand("spotifymlh.history.newer");
         }
 
-        return Promise.resolve(this.tracks);
+        return Promise.resolve(this.tracks.concat([new LoadMoreTracks]));
     }
 
     getTreeItem(element: Track): vscode.TreeItem {
@@ -44,5 +81,25 @@ export class HistoryProvider implements vscode.TreeDataProvider<Track> {
             },
             error => vscode.window.showErrorMessage(error)
         ));
+    }
+}
+
+/**
+ * A placeholder Track that loads more history when clicked
+ * @extends Track
+ */
+class LoadMoreTracks extends Track {
+    constructor() {
+        super({
+            name: "Load more...",
+            artists: [],
+            uri: undefined
+        });
+        this.command = {
+            command: "spotifymlh.history.older",
+            title: "Load older play history"
+        };
+        this.contextValue = undefined; // Don't show track actions
+        this.tooltip = "Load older play history";
     }
 }

--- a/src/track.ts
+++ b/src/track.ts
@@ -8,12 +8,15 @@ import * as vscode from 'vscode';
 export default class Track extends vscode.TreeItem {
     artists: any[];
     name: string;
+    uri: string;
+    
     constructor(
-        private readonly track: any
+        public readonly data: any
     ) {
-        super(track.name);
-        this.name = track.name;
-        this.artists = track.artists;
+        super(data.name);
+        this.name = data.name;
+        this.artists = data.artists;
+        this.uri = data.uri;
 
         this.description = this.artists.map(x => x.name).join(', ');
         this.tooltip = new vscode.MarkdownString(`**${this.name}**  \n${this.artists.map(x => x.name).join(', ')}`);

--- a/src/track.ts
+++ b/src/track.ts
@@ -14,6 +14,7 @@ export default class Track extends vscode.TreeItem {
         public readonly data: any
     ) {
         super(data.name);
+        this.contextValue = 'track';
         this.name = data.name;
         this.artists = data.artists;
         this.uri = data.uri;


### PR DESCRIPTION
Resolves #8 and partially addresses #14

**Actions:**
- [x] Add track to queue
- [x] Play track immediately
- [x] Refresh panel (gets new history entries)
- [x] **Load more...** button (gets older history entries)

**Miscellaneous:**
- [x] Filter actions by track context (instead of hardcoding a panel ID)