### PR TITLE
Bootstrap playback upon connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
 	"contributes": {
 		"commands": [
 			{
+				"command": "spotifymlh.bootstrap",
+				"title": "Bootstrap playback"
+			},
+			{
 				"command": "spotifymlh.history.newer",
 				"title": "Load newer tracks",
 				"icon": "$(refresh)"

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -49,10 +49,11 @@ export class SpotifyCallbackHandler implements vscode.UriHandler {
             data => {
                 this.spotify.setAccessToken(data.body['access_token']);
                 this.spotify.setRefreshToken(data.body['refresh_token']);
-                vscode.window.showInformationMessage("Successfully authenticated with Spotify.");
+                // Ensure we connect to a device
+                vscode.commands.executeCommand('spotifymlh.bootstrap');
             },
             err => {
-                vscode.window.showErrorMessage(`Error exchanging authorization code for access token: ${err}`);
+                vscode.window.showErrorMessage(`Error exchanging authorization code for access token: ${err.message}`);
             }
         );
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,20 +24,20 @@ export function activate(context: vscode.ExtensionContext) {
 	// Set up command to bootstrap playback, called in openAuthWindow()
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.bootstrap", () => {
 		spotify.getMyDevices()
-		.then(
-			data => {
-				if (data.body.devices.length < 1) {
-					vscode.window.showInformationMessage("No Spotify clients are online. Open Spotify and try again. If you already have a Spotify device running, try playing a track directly on it to register it with the Spotify API.");
-					return;
-				}
-
-				let device = data.body.devices[0];
-				if (!device.is_active) {
-					return spotify.transferMyPlayback([device.id ?? ""])
-					.then(() => vscode.window.showInformationMessage(`Successfully connected to ${device.name}.`) );
-				}
+		.then(data => {
+			if (data.body.devices.length < 1) {
+				vscode.window.showInformationMessage("No Spotify clients are online. Open Spotify and try again. If you already have a Spotify device running, try playing a track directly on it to register it with the Spotify API.");
+				return;
 			}
-		)
+
+			let device = data.body.devices[0];
+			if (!device.is_active) {
+				return spotify.transferMyPlayback([device.id ?? ""])
+				.then(() => vscode.window.showInformationMessage(`Successfully connected to ${device.name}.`));
+			}
+
+			vscode.window.showInformationMessage(`Successfully connected to ${device.name}.`);
+		})
 		.catch(error => vscode.window.showErrorMessage(error.message));
 	}));
 


### PR DESCRIPTION
Closes #29

This attempts to force connecting to a Spotify device right after authorization. The standard authorization success message is replaced with a message saying which device is connected.

This PR needs some testing because I'm not sure if Spotify likes transferring playback from the same device to itself. If it gets glitchy, we can cache the device ID and explicitly specify it for all playback commands.