### PR TITLE
Fix error message display

### DIFF
--- a/src/albums.ts
+++ b/src/albums.ts
@@ -21,7 +21,7 @@ export class AlbumsProvider implements vscode.TreeDataProvider<AlbumsAndTracks> 
       const albums = await this.spotify.getMySavedAlbums();
       return albums.body.items.map((data) => new AlbumsAndTracks(data, this.spotify));
       } catch (err: any) {
-      vscode.window.showErrorMessage(err);
+      vscode.window.showErrorMessage(err.message);
     }
   }
 }

--- a/src/artists.ts
+++ b/src/artists.ts
@@ -21,7 +21,7 @@ export class ArtistsProvider implements vscode.TreeDataProvider<ArtistsAndTracks
       const artists = await this.spotify.getFollowedArtists();
       return artists.body.artists.items.map((data) => new ArtistsAndTracks(data, this.spotify));
       } catch (err: any) {
-      vscode.window.showErrorMessage(err);
+      vscode.window.showErrorMessage(err.message);
     }
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,63 +46,68 @@ export function activate(context: vscode.ExtensionContext) {
   
 
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.play", () => {
-        vscode.window.showInformationMessage('Attempting to play...');
-		spotify.play();
+		spotify.play()
+			.catch(error => vscode.window.showErrorMessage(error.message));
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.pause", () => {
-		// TODO: handle errors etc., see documentation
-		vscode.window.showInformationMessage('Attempting to pause...');
-		spotify.pause();
+		spotify.pause()
+			.catch(error => vscode.window.showErrorMessage(error.message));
 	}));
 
     context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.previous", () => {
-		// TODO: handle errors etc., see documentation
-		vscode.window.showInformationMessage('Playing the previous song...');
-		spotify.skipToPrevious();
+		spotify.skipToPrevious()
+			.catch(error => vscode.window.showErrorMessage(error.message));
 	}));
 
     context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.next", () => {
-		// TODO: handle errors etc., see documentation
-		vscode.window.showInformationMessage('Playing the next song...');
-		spotify.skipToNext();
+		spotify.skipToNext()
+			.catch(error => vscode.window.showErrorMessage(error.message));
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.track.play", (track: Track) => {
 		// Spotify Web API doesn't currently have a way to start playback fresh from a track, so this is a hack
 		spotify.addToQueue(track.uri)
-			.then(() => spotify.skipToNext());
+			.then(() => spotify.skipToNext())
+			.catch(error => vscode.window.showErrorMessage(error.message));
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.track.queue", (track: Track) => {
-		spotify.addToQueue(track.uri);
+		spotify.addToQueue(track.uri)
+			.catch(error => vscode.window.showErrorMessage(error.message));
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.playlisttrack.play", (playlistAndTracks: PlaylistAndTracks) => {
 		spotify.addToQueue(playlistAndTracks.uri)
-		.then(() => spotify.skipToNext());
+			.then(() => spotify.skipToNext())
+			.catch(error => vscode.window.showErrorMessage(error.message));
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.playlisttrack.queue", (playlistAndTracks: PlaylistAndTracks) => {
-		spotify.addToQueue(playlistAndTracks.uri);
+		spotify.addToQueue(playlistAndTracks.uri)
+			.catch(error => vscode.window.showErrorMessage(error.message));
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.albumtrack.play", (albumsAndTracks: AlbumsAndTracks) => {
 		spotify.addToQueue(albumsAndTracks.uri)
-		.then(() => spotify.skipToNext());
+			.then(() => spotify.skipToNext())
+			.catch(error => vscode.window.showErrorMessage(error.message));
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.albumtrack.queue", (albumAndTracks: AlbumsAndTracks) => {
-		spotify.addToQueue(albumAndTracks.uri);
+		spotify.addToQueue(albumAndTracks.uri)
+			.catch(error => vscode.window.showErrorMessage(error.message));
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.artisttrack.play", (artistAndTracks: ArtistsAndTracks) => {
 		spotify.addToQueue(artistAndTracks.uri)
-		.then(() => spotify.skipToNext());
+			.then(() => spotify.skipToNext())
+			.catch(error => vscode.window.showErrorMessage(error.message));
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.artisttrack.queue", (artistAndTracks: ArtistsAndTracks) => {
-		spotify.addToQueue(artistAndTracks.uri);
+		spotify.addToQueue(artistAndTracks.uri)
+			.catch(error => vscode.window.showErrorMessage(error.message));
 	}));
 
 	

--- a/src/history.ts
+++ b/src/history.ts
@@ -32,7 +32,7 @@ export class HistoryProvider implements vscode.TreeDataProvider<Track> {
                     this.tracks = data.body.items.map((x: any) => new Track(x.track)).concat(this.tracks);
                     this._onDidChangeTreeData.fire(); // Tell VS Code that the TreeItems have changed
                 },
-                error => vscode.window.showErrorMessage(error)
+                error => vscode.window.showErrorMessage(error.message)
             );
         }));
         context.subscriptions.push(vscode.commands.registerCommand("spotifymlh.history.older", () => {
@@ -46,7 +46,7 @@ export class HistoryProvider implements vscode.TreeDataProvider<Track> {
                     this.tracks.push(...data.body.items.map((x: any) => new Track(x.track)));
                     this._onDidChangeTreeData.fire(); // Tell VS Code that the TreeItems have changed
                 },
-                error => vscode.window.showErrorMessage(error)
+                error => vscode.window.showErrorMessage(error.message)
             );
         }));
     }
@@ -79,7 +79,7 @@ export class HistoryProvider implements vscode.TreeDataProvider<Track> {
                 this.tracks = data.body.items.map((x: any) => new Track(x.track)).concat(this.tracks);
                 this._onDidChangeTreeData.fire(); // Tell VS Code that the TreeItems have changed
             },
-            error => vscode.window.showErrorMessage(error)
+            error => vscode.window.showErrorMessage(error.message)
         ));
     }
 }


### PR DESCRIPTION
Some Spotify API errors are uncaught, and most catches display the `error` object directly, which fails silently. Instead we should be displaying `error.message`.